### PR TITLE
Update Mongoose and Update Compose steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,30 +6,16 @@ sudo: required
 services:
   - docker
 
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck
-
-matrix:
-  fast_finish: true
-
-env:
-  - TEST_RUN="./tests/test-docker.sh"
 
 before_install:
-  - npm install eslint html-lint csslint
+  - sudo apt-get install shellcheck
   - sudo pip install yamllint
-
-install: true
+  - git clone https://github.com/IBM/pattern-ci
 
 before_script:
-  - "./tests/test-csslint.sh"
-  - "./tests/test-eslint.sh"
-  - "./tests/test-html-lint.sh"
-  - "./tests/test-shellcheck.sh"
-  - "./tests/test-yamllint.sh"
+  - "./pattern-ci/tests/shellcheck-lint.sh"
+  - "./pattern-ci/tests/yaml-lint.sh"
 
-script: "$TEST_RUN"
+jobs:
+  include:
+    - script: ./tests/test-docker.sh

--- a/containers/map-api/app.js
+++ b/containers/map-api/app.js
@@ -2,7 +2,6 @@ const express = require("express");
 const app = express();
 const mongoose = require("mongoose");
 const assert = require("assert");
-const fs = require("fs");
 const cors = require("cors");
 
 const beaconRoute = require("./routes/beacons");
@@ -13,26 +12,13 @@ const renderRoute = require("./routes/renderSvg");
 
 const mongoDbUrl = process.env.MONGODB_URL;
 
-let ca;
-if (process.env.MONGODB_CERT_BASE64) { // if encoded certificate is set in ENV, use it.
-  ca = new Buffer(process.env.MONGODB_CERT_BASE64, "base64");
-} else if (fs.existsSync("/etc/ssl/mongo.cert")) { // if mongo.cert exists, use it
-  ca = [fs.readFileSync("/etc/ssl/mongo.cert")];
-} else if (process.env.UNIT_TEST == "test") { // if a test, don't do anything.
-  console.log("This is a test. Run a local mongoDB.");
-} else {
-  console.log("No certificate provided!");
-}
-
 let mongoDbOptions = {
-  mongos: {
-    useMongoClient: true,
-    ssl: true,
-    sslValidate: true,
-    sslCA: ca,
-  },
+  // ssl: true,
+  // sslValidate: true,
+  useNewUrlParser: true
 };
 
+mongoose.set('useCreateIndex',true);
 mongoose.connection.on("error", function(err) {
   console.log("Mongoose default connection error: " + err);
 });

--- a/containers/map-api/package.json
+++ b/containers/map-api/package.json
@@ -21,15 +21,15 @@
     "ejs": "^2.5.7",
     "express": "^4.15.x",
     "fs": "~0.0.1",
-    "mongoose": "^4.13.x",
+    "mongoose": "^5.2.x",
     "pdfkit": "^0.8.3",
     "router": "^1.3.2",
     "svg-to-pdfkit": "^0.1.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "chai-http": "^2.0.1",
-    "mocha": "^2.4.5"
+    "chai-http": "^4.2.0",
+    "mocha": "^5.2.0"
   },
   "author": "Anthony Amanse",
   "license": "Apache-2.0"

--- a/containers/map-api/routes/events.js
+++ b/containers/map-api/routes/events.js
@@ -11,35 +11,38 @@ router.post("/add", function(req, res) {
   // Insert input validation
   let boothIds = req.body.map;
   let beaconIds = req.body.beacons;
+  console.log(boothIds);
+  console.log(beaconIds);
 
-  let queryBooth = Booths.find({"boothId": {$in: boothIds}},
+  Booths.find({"boothId": {$in: boothIds}},
     function(err, booths) {
       if (err) {
+        console.log("error in booth query");
         res.send(err);
       } else {
         req.body.map = booths;
-      }
-    });
+        Beacons.find({"beaconId": {$in: beaconIds}},
+          function(err, beacons) {
+            if (err) {
+              console.log("error in beacon query");
+              res.send(err);
+            } else {
+              req.body.beacons = beacons;
 
-  let queryBeacon = Beacons.find({"beaconId": {$in: beaconIds}},
-    function(err, beacons) {
-      if (err) {
-        res.send(err);
-      } else {
-        req.body.beacons = beacons;
-      }
-    });
+              let addEvent = new Events(req.body);
+              addEvent.save(function(err) {
+                if (err) {
+                  console.log(req.body);
+                  console.log("error in add event");
+                  res.send(err);
+                } else {
+                  res.send("Saved event.");
+                }
+              });
 
-  queryBooth.then(queryBeacon)
-    .then(function() {
-      let addEvent = new Events(req.body);
-      addEvent.save(function(err) {
-        if (err) {
-          res.send(err);
-        } else {
-          res.send("Saved event.");
-        }
-      });
+            }
+          });
+      }
     });
 });
 

--- a/curl-mockdata.sh
+++ b/curl-mockdata.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+curl -X POST -H 'Content-type: application/json' -d '{ "beaconId" : "B01", "x" : 2, "y" : 5, "minCount" : 1, "maxCount" : 100 }' "$1"/beacons/add
+curl -X POST -H 'Content-type: application/json' -d '{ "beaconId" : "B02", "x" : 11, "y" : 4, "minCount" : 1, "maxCount" : 100 }' "$1"/beacons/add
+curl -X POST -H 'Content-type: application/json' -d '{ "beaconId" : "B03", "x" : 19, "y" : 20, "minCount" : 1, "maxCount" : 100 }' "$1"/beacons/add
+curl -X POST -H 'Content-type: application/json' -d '{ "beaconId" : "B04", "x" : 10, "y" : 11, "minCount" : 1, "maxCount" : 100 }' "$1"/beacons/add
+
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A01", "unit" : "Node", "description" : "Node description", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 3, "height" : 3, "x" : 0, "y" : 0}, "contact" : "John Doe" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A02", "unit" : "MongoDB", "description" : "MongoDB is not a relational database", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 5, "height" : 4, "x" : 16, "y" : 1}, "contact" : "Mary Jane" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A03", "unit" : "Swift", "description" : "Swift is not just for iOS", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 6, "height" : 2, "x" : 6, "y" : 4}, "contact" : "Jane Doe" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A04", "unit" : "VR", "description" : "Virtual Reality is growing", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 9, "height" : 7, "x" : 4, "y" : 8}, "contact" : "Smith John" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A05", "unit" : "Watson", "description" : "IBM Watson.", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 3, "height" : 5, "x" : 16, "y" : 8}, "contact" : "Catherine May" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A06", "unit" : "Info", "description" : "Information Booth", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 7, "height" : 3, "x" : 11, "y" : 17}, "contact" : "Ben Jerry" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A07", "unit" : "IBM Cloud", "description" : "Used to be called Bluemix", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 4, "height" : 4, "x" : 3, "y" : 17}, "contact" : "Joe Myers" }' "$1"/booths/add
+sleep 1s
+curl -X POST -H 'Content-type: application/json' -d '{ "eventId" : "index", "eventName" : "Index", "location" : "San Francisco", "x" : 21, "y" : 21,"startDate" : "2018-02-20T00:00:00Z", "endDate" : "2018-02-24T00:00:00Z", "beacons" : ["B01","B02","B03","B04"], "map" : ["A01","A02","A03","A04","A05","A06","A07"] }' "$1"/events/add
+
+curl -X POST -H 'Content-type: application/json' -d '{ "beaconId" : "B11", "x" : 2, "y" : 5, "minCount" : 1, "maxCount" : 100 }' "$1"/beacons/add
+curl -X POST -H 'Content-type: application/json' -d '{ "beaconId" : "B12", "x" : 11, "y" : 4, "minCount" : 1, "maxCount" : 100 }' "$1"/beacons/add
+curl -X POST -H 'Content-type: application/json' -d '{ "beaconId" : "B13", "x" : 19, "y" : 20, "minCount" : 1, "maxCount" : 100 }' "$1"/beacons/add
+curl -X POST -H 'Content-type: application/json' -d '{ "beaconId" : "B14", "x" : 10, "y" : 11, "minCount" : 1, "maxCount" : 100 }' "$1"/beacons/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A11", "unit" : "Node", "description" : "Node description", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 10, "height" : 5, "x" : 1, "y" : 1}, "contact" : "John Doe" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A12", "unit" : "MongoDB", "description" : "MongoDB is not a relational database", "measurementUnit" : "metre", "shape" : {"type": "rectangle", "width" : 5, "height" : 35, "x" : 40, "y" : 1}, "contact" : "Mary Jane" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A13", "unit" : "Swift", "description" : "Swift is not just for iOS", "measurementUnit" : "metre", "shape" : {"type": "circle", "radius" : 3, "cx" : 6, "cy" : 15}, "contact" : "Jane Doe" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A14", "unit" : "VR", "description" : "Virtual Reality is growing", "measurementUnit" : "metre", "shape" : {"type": "ellipse", "cx" : 18, "cy" : 32, "rx" : 13, "ry" : 3}, "contact" : "Smith John" }' "$1"/booths/add
+curl -X POST -H 'Content-type: application/json' -d '{ "boothId" : "A15", "unit" : "Watson", "description" : "IBM Watson.", "measurementUnit" : "metre", "shape" : {"type": "polygon", "points" : "22,1 30,21 17,25 13,23"}, "contact" : "Catherine May" }' "$1"/booths/add
+sleep 1s
+curl -X POST -H 'Content-type: application/json' -d '{ "eventId" : "think", "eventName" : "Think", "location" : "Las Vegas", "x" : 46, "y" : 37, "startDate" : "2018-03-19T00:00:00Z", "endDate" : "2018-03-22T00:00:00Z", "beacons" : ["B11","B12","B13","B14"], "map" : ["A11","A12","A13","A14","A15"] }' "$1"/events/add

--- a/manifests/map-api.yaml
+++ b/manifests/map-api.yaml
@@ -29,18 +29,14 @@ spec:
         app: map-api-test
     spec:
       containers:
-        - image: anthonyamanse/map-api:2.0
+        - image: anthonyamanse/map-api:3.0
+          imagePullPolicy: Always
           name: map-api
           env:
             - name: MONGODB_URL
-              value: ''
-          volumeMounts:
-            - name: mongodb-cert
-              mountPath: "/etc/ssl"
-              readOnly: true
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-url
+                  key: MONGODB_URL
           ports:
             - containerPort: 8080
-      volumes:
-        - name: mongodb-cert
-          secret:
-            secretName: mongodb-cert-secret

--- a/manifests/mongo.yaml
+++ b/manifests/mongo.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+spec:
+  ports:
+    - port: 27017
+      targetPort: 27017
+  type: ClusterIP
+  selector:
+    app: mongodb
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mongodb
+    spec:
+      containers:
+        - image: mongo
+          name: mongodb
+          ports:
+            - containerPort: 27017
+# Note:
+# For testing, this Mongo instance will not
+# persist the data and will stay in the container.
+# When the container is deleted or restarted, data will be lost.
+# If you want a persistent Mongo instance,
+# mount a volume in /data/db

--- a/mongo-cert-secret.yaml
+++ b/mongo-cert-secret.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mongodb-cert-secret
-type: Opaque
-data:
-  mongo.cert: ''


### PR DESCRIPTION
This commit updates the version of mongoose to the current latest (5.2).

This commit also updates the use of Compose for MongoDB. The service is
now using Let's Encrypt certificates. Previously, a provided certificate
was needed to be mounted for connection. The MongoDB URL is now using a
secret in map-api.yaml instead of a plain environment variable.

This commit also adds an alternative to compose. This commit adds a new
yaml file for a MongoDB container in Kubernetes for testing/development.

This commit also moves the yaml files in the manifests folder.

Fixes #9, Fixes #10

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>